### PR TITLE
Fix ValueError when parsing pod positions with decimal values from WolframAlpha API

### DIFF
--- a/WolframAlpha/plugin.py
+++ b/WolframAlpha/plugin.py
@@ -191,7 +191,7 @@ class WolframAlpha(callbacks.Plugin):
             # each answer has a different amount of pods.
             for pod in document.findall(".//pod"):
                 title = pod.attrib["title"]  # title of it.
-                position = int(pod.attrib["position"])  # store pods int when we sort.
+                position = float(pod.attrib["position"])  # store pods int when we sort.
                 outputlist[position] = title  # pu
                 for plaintext in pod.findall(".//plaintext"):
                     if plaintext.text:


### PR DESCRIPTION
The WolframAlpha API sometimes returns 'position' attributes as decimal strings (e.g., '2210.001'), which caused a ValueError when attempting to cast them to integers using `int()`. This commit updates the code to use `float()` instead, allowing parsing of both integer and decimal position values.

Also ensures compatibility with sorted output logic, since float keys can still be ordered reliably.

Fixes: uncaught exception on certain queries with float-based pod positions.