### PR TITLE
Fix channel worst time updating for DuckHunt plugin

### DIFF
--- a/DuckHunt/plugin.py
+++ b/DuckHunt/plugin.py
@@ -138,7 +138,7 @@ class DuckHunt(callbacks.Plugin):
             else:
                 # It's a player that already has a saved score
                 # And we save the time of the current hunt if it's worst than it's previous time
-                if self.worsttimes[channel][player] > value:
+                if self.channelworsttimes[channel][player] < value:
                     self.channelworsttimes[channel][player] = value
 
         # # week scores


### PR DESCRIPTION
Longest times were not updating because self.worsttimes[channel][player] was being compared to itself instead of self.channelworsttimes[channel][player]

This PR fixes that issue